### PR TITLE
Ignore hidden (.*) directories

### DIFF
--- a/composer.py
+++ b/composer.py
@@ -18,7 +18,7 @@ in exclude_containers[exclude_containers.find('=')+1:].split(',')]
 
 compose_dirs = []
 for dir in os.listdir(compose_path):
-    if os.path.isdir(compose_path + dir) and dir not in exclude_containers:
+    if os.path.isdir(compose_path + dir) and dir not in exclude_containers and dir[0] != '.':
         compose_dirs.append(compose_path + dir + '/')
 
 containers = []


### PR DESCRIPTION
This ignores hidden directories, such as .git, when running composer.py